### PR TITLE
Atualizar comando para scraping de áreas via site do PGCOMP

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -33,26 +33,23 @@ Responsável pelo serviço de recuperação dos dados (através de web scraping)
 
 ### Iniciar projeto backend
 ```bash
+
 # Iniciar projeto backend
-docker-compose exec php bash
-composer install
-php artisan migrate #(ou importar dump do banco de dados)
+./vendor/bin/sail artisan migrate #(ou importar dump do banco de dados)
 
 # SIGAA Web Scraping
-docker-compose exec php bash
-php artisan scraping:sigaa-scraping --help
-php artisan scraping:sigaa-scraping ID_DO_PROGRAMA #(o ID do PGCOMP é 1820)
-php artisan scraping:area-subarea-scraping
-php artisan scraping:qualis-conference-scraping
-php artisan scraping:qualis-journal-scraping
+./vendor/bin/sail artisan scraping:sigaa-scraping --help
+./vendor/bin/sail artisan scraping:sigaa-scraping ID_DO_PROGRAMA #(o ID do PGCOMP é 1820)
+./vendor/bin/sail artisan scraping:area-subarea-scraping
+./vendor/bin/sail artisan scraping:qualis-conference-scraping
+./vendor/bin/sail artisan scraping:qualis-journal-scraping
 
 # Carregando arquivos xml do lattes
-php artisan load:lattes-files-load
+./vendor/bin/sail artisan load:lattes-files-load
 
 # Recriar base de dados
-docker-compose exec php bash
-php artisan migrate:fresh #(Isso apagará todos os dados!)
+./vendor/bin/sail artisan migrate:fresh #(Isso apagará todos os dados!)
 
 # Inserir dados falsos
-php artisan db:seed #(Somente deve ser executado após de realizar o scraping)
+./vendor/bin/sail artisan db:seed #(Somente deve ser executado após de realizar o scraping)
 ```

--- a/backend/app/Console/Commands/AreaSubareaCommand.php
+++ b/backend/app/Console/Commands/AreaSubareaCommand.php
@@ -3,12 +3,10 @@
 namespace App\Console\Commands;
 
 use App\Models\Area;
-use App\Models\Program;
-use App\Models\Subarea;
-use App\Models\User;
-use Google\Client;
-use Google\Service\Sheets;
+
+use GuzzleHttp\Client;
 use Illuminate\Console\Command;
+use Illuminate\Support\Str;
 
 class AreaSubareaCommand extends Command
 {
@@ -16,51 +14,72 @@ class AreaSubareaCommand extends Command
 
     protected $description = 'Área Sub-area';
 
+
     public function handle()
     {
-        //https://docs.google.com/spreadsheets/d/1IxNKhESNGSNqsOnz3f6cWB5njxDQaxB80EtPTtCRT0A/edit#gid=0
-        $sheet = $this->getSheet();
 
-        $this->getOutput()->info('Buscando dados...');
-        $values = $sheet->spreadsheets_values
-            ->get('1IxNKhESNGSNqsOnz3f6cWB5njxDQaxB80EtPTtCRT0A', 'A:D')
-            ->values;
+        // Access https://pgcomp.ufba.br/area-de-concentracao, get the areas and access its link to get the subareas
+        $client = new Client();
+        $response = $client->request('GET', 'https://pgcomp.ufba.br/area-de-concentracao');
+        $html = $response->getBody()->getContents();
+        $dom = html5qp($html);
 
-        $this->getOutput()->info('Ajustando dados...');
-        $header = collect(array_shift($values));
-        $data = collect($values)->transform(fn($item) => $header->combine($item)->all());
+        // Get areas after the first h1 tag with the text "Área de Concentração"
+        $areas = $dom->find('h1:contains("Área de Concentração")')->text();
+        $areas = $dom->find('.region.region-content .field-items ul > li')->getIterator();
 
-        $programId = Program::where('sigaa_id', 1820)->firstOrFail()->id;
-        foreach ($data as $item) {
-            $area = Area::updateOrCreate(['area_name' => $item['area'], 'program_id' => $programId]);
-            $subArea = null;
-            if ($item['subarea']) {
-                $subArea = Subarea::updateOrCreate(['subarea_name' => $item['subarea'], 'area_id' => $area->id]);
-            }
-            $user = User::where('siape', $item['siape'])->first();
-            if (empty($user)) {
-                $this->error("User siape {$item['siape']} not found.");
-                continue;
-            }
-            $user->subarea_id = $subArea?->id;
-            $user->save();
+        foreach ($areas as $area) {
+            // Get the area name. Find until the first dot ".'
+            $areaName = $area->text();
+            $areaName = Str::of($areaName)->before('.')->trim()->title()->value();
 
-            $user->advisedes()->update(['subarea_id' => $subArea?->id]);
-            if ($subArea) {
-                $user->subareas()->attach($subArea->id);
-                $user->advisedes->each(fn (User $u) => $u->subareas()->attach($subArea->id));
-            }
+            $areaLink = $area->find('a')->attr('href');
+
+            $this->generateSubArea($areaName, $areaLink);
         }
     }
 
-    protected function getSheet(): Sheets
+    private function generateSubArea(string $areaName, string $areaUrl): void
     {
-        $cliente = new Client();
-        $cliente->setAuthConfig(base_path('google-ufba.json'));
 
-        $cliente->setApplicationName('mate85-sheets');
-        $cliente->addScope(Sheets::SPREADSHEETS_READONLY);
+        $this->info("Acessando a área: $areaName");
+        $subAreas = $this->getSubAreas($areaName, $areaUrl);
 
-        return new Sheets($cliente);
+        $rows = [];
+        foreach ($subAreas as $subAreaName) {
+            $area = Area::updateOrCreate(
+                ['area' => $areaName, 'subarea' => $subAreaName]
+            );
+            $rows[] = [$area->id, $area->area, $area->subarea, $area->wasRecentlyCreated ? 'Sim' : 'Não'];
+        }
+        $this->table(
+            ['ID', 'Área', 'Subárea', 'Criada'],
+            $rows
+        );
+    }
+
+    private function getSubAreas(string $areaName, string $areaUrl): array
+    {
+        // "Engenharia de Software" is a special case. PGCOMP site does not have an explicit subarea for it.
+        if ($areaName == "Engenharia De Software") {
+            return  [
+                "Engenharia de Software"
+            ];
+        }
+
+        // Access the area link and get the subareas
+        $client = new Client();
+        $response = $client->request('GET', $areaUrl);
+        $html = $response->getBody()->getContents();
+        $dom = html5qp($html);
+        $subAreasIterator = $dom->find('.region.region-content .field-items ul > li')->getIterator();
+
+        foreach ($subAreasIterator as $subArea) {
+            // Get the subarea name. Find until the first dot ".'
+            $subAreaName = $subArea->text();
+            $subAreaName = Str::of($subAreaName)->before('.')->trim()->title()->value();
+            $subAreas[] = $subAreaName;
+        }
+        return $subAreas;
     }
 }


### PR DESCRIPTION
Substituição da integração com o Planilhas Google na classe `AreaSubareaCommand` por uma implementação de web scraping. A nova abordagem busca dados de áreas e subáreas diretamente do site do PGCOMP (`https://pgcomp.ufba.br/area-de-concentracao`) usando `GuzzleHttp\Client` e `html5qp`. 
