### PR TITLE
Atualizar área dos professores no SigaaScraping

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -37,10 +37,13 @@ Responsável pelo serviço de recuperação dos dados (através de web scraping)
 # Iniciar projeto backend
 ./vendor/bin/sail artisan migrate #(ou importar dump do banco de dados)
 
+# Gerar chave de autenticação
+./vendor/bin/sail artisan key:generate
+
 # SIGAA Web Scraping
-./vendor/bin/sail artisan scraping:sigaa-scraping --help
-./vendor/bin/sail artisan scraping:sigaa-scraping ID_DO_PROGRAMA #(o ID do PGCOMP é 1820)
 ./vendor/bin/sail artisan scraping:area-subarea-scraping
+./vendor/bin/sail artisan scraping:sigaa-scraping --help
+./vendor/bin/sail artisan scraping:sigaa-scraping
 ./vendor/bin/sail artisan scraping:qualis-conference-scraping
 ./vendor/bin/sail artisan scraping:qualis-journal-scraping
 

--- a/backend/app/Console/Commands/AreaSubareaCommand.php
+++ b/backend/app/Console/Commands/AreaSubareaCommand.php
@@ -25,7 +25,6 @@ class AreaSubareaCommand extends Command
         $dom = html5qp($html);
 
         // Get areas after the first h1 tag with the text "Área de Concentração"
-        $areas = $dom->find('h1:contains("Área de Concentração")')->text();
         $areas = $dom->find('.region.region-content .field-items ul > li')->getIterator();
 
         foreach ($areas as $area) {
@@ -42,9 +41,8 @@ class AreaSubareaCommand extends Command
     private function generateSubArea(string $areaName, string $areaUrl): void
     {
 
-        $this->info("Acessando a área: $areaName");
+        $this->info("\nAcessando a área: $areaName");
         $subAreas = $this->getSubAreas($areaName, $areaUrl);
-
         $rows = [];
         foreach ($subAreas as $subAreaName) {
             $area = Area::updateOrCreate(

--- a/backend/app/Domain/Sigaa/BaseScraping.php
+++ b/backend/app/Domain/Sigaa/BaseScraping.php
@@ -5,7 +5,7 @@ namespace App\Domain\Sigaa;
 use Exception;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
-use Log;
+use Illuminate\Support\Facades\Log;
 use QueryPath\DOMQuery;
 
 abstract class BaseScraping

--- a/backend/app/Domain/Sigaa/TeacherScraping.php
+++ b/backend/app/Domain/Sigaa/TeacherScraping.php
@@ -2,6 +2,11 @@
 
 namespace App\Domain\Sigaa;
 
+use App\Enums\UserType;
+use App\Models\Area;
+use App\Models\User;
+use DOMDocument;
+use DOMXPath;
 use Exception;
 use Illuminate\Support\Str;
 use QueryPath\DOMQuery;
@@ -9,20 +14,42 @@ use QueryPath\DOMQuery;
 class TeacherScraping extends BaseScraping
 {
     /**
+     * @var array $key: Missmatch name, $value: Correct name in the database
+     */
+    private const MISS_MATCH_PROFESSORS = [
+        'Christina von Flach G. Chavez' => 'Christina Von Flach Garcia Chavez',
+        'Claudio Nogueira Sant’Anna' => 'Claudio Nogueira Sant Anna',
+    ];
+
+    private const SIGAA_URL = 'https://sigaa.ufba.br/sigaa/public/programa/equipe.jsf';
+    private const PGCOMP_AREA_URL = 'https://pgcomp.ufba.br/area-de-concentracao';
+
+    /**
+     * @var array $key: Name of the professor, $value: array with the area_id and id of the professor
+     */
+    private array $professorsWithArea = [];
+
+    /**
      * Realiza o web scraping de professores no site SIGAA
      *
      * @throws Exception
      */
     public function scrapingByProgram(int $programId): array
     {
-        $dom = $this->getDOMQuery('https://sigaa.ufba.br/sigaa/public/programa/equipe.jsf', ['id' => $programId]);
+        $this->fillProfessorsWithArea();
+
+        $dom = $this->getDOMQuery(self::SIGAA_URL, ['id' => $programId]);
         $items = $dom->find('#equipePrograma table#table_lt tr')->getIterator();
         $teachers = [];
         foreach ($items as $item) {
             if ($item->hasClass('campos')) {
                 continue;
             }
-            $teachers[] = $this->extractTeacher($item);
+            $teacher = $this->extractTeacher($item);
+
+            $teacher['area_id'] = $this->professorsWithArea[$teacher['name']]['area_id'] ?? null;
+
+            $teachers[] = $teacher;
         }
 
         return $teachers;
@@ -67,5 +94,97 @@ class TeacherScraping extends BaseScraping
         $email = Str::of($email)->trim()->lower()->after('mailto:')->value() ?: null;
 
         return compact('name', 'relation', 'level', 'telephone', 'lattes_url', 'email', 'siape');
+    }
+
+    /**
+     * Finds the professors with area and subarea and fills the professorsWithArea array
+     * @return void
+     */
+    private function fillProfessorsWithArea()
+    {
+
+        // Access https://pgcomp.ufba.br/area-de-concentracao, get the areas and access its link to get the subareas
+        $dom = $this->getDOMQuery(self::PGCOMP_AREA_URL);
+
+        // Get areas after the first h1 tag with the text "Área de Concentração"
+        $areas = $dom->find('.region.region-content .field-items ul > li')->getIterator();
+
+        foreach ($areas as $area) {
+            // Get the area name. Find until the first dot ".'
+            $areaName = $area->text();
+            $areaName = Str::of($areaName)->before('.')->trim()->title()->value();
+
+            $areaLink = $area->find('a')->attr('href');
+
+            $this->getProfessors($areaName, $areaLink);
+        }
+    }
+
+    /**
+     * Get the professors from the area
+     * @param string $areaName Name of the area
+     * @param string $areaUrl URL of the area
+     * @return void
+     */
+    private function getProfessors(string $areaName, string $areaUrl): void
+    {
+        $dom = $this->getDOMQuery($areaUrl);
+        if ($areaName == "Engenharia De Software") {
+            $html = $dom->html();
+            // Convert to DOMDocument
+            $dom = new DOMDocument();
+            libxml_use_internal_errors(true); // Suppress HTML5 warnings
+            $dom->loadHTML($html);
+            libxml_clear_errors();
+            $xpath = new DOMXPath($dom);
+            $nodes = $xpath->query("//h3[contains(., 'Pesquisadores')]/following-sibling::ul[1]/li");
+            $professors = [];
+            foreach ($nodes as $node) {
+                $professor = trim($node->textContent);
+                if (!empty($professor)) {
+                    $this->extractProfessorsAreaSubarea($professor, $areaName);
+                }
+            }
+            return;
+        }
+        // Access the area link and get the professors
+        $divs = $dom->find('.field-items > .field-item.even')->children('div');
+        $content = $divs->eq($divs->length - 2)->text();
+        $content = Str::of($content)->trim()->after('Pesquisadores:')->before('.')->value();
+        $professors = explode(',', $content);
+        $professors = array_map(function ($professor) use ($areaName) {
+            $professor = Str::of($professor)->trim()->title()->value();
+            return $this->extractProfessorsAreaSubarea($professor, $areaName);
+        }, $professors);
+    }
+
+    /**
+     * Extract and fill the professors with an random subarea of the area
+     * @param string $professorName Name of the professor
+     * @param string $areaName Name of the area
+     * @return void
+     */
+    private function extractProfessorsAreaSubarea(string $professorName, string $areaName): void
+    {
+        if (isset(self::MISS_MATCH_PROFESSORS[$professorName])) {
+            $professorName = self::MISS_MATCH_PROFESSORS[$professorName];
+        }
+
+        $names = explode(' ', $professorName);
+        $user = User::where('type', UserType::PROFESSOR)
+            ->where(function ($query) use ($names) {
+                foreach ($names as $name) {
+                    $query->where('name', 'like', "%$name%");
+                }
+            })
+            ->first();
+        if (empty($user)) {
+            return;
+        }
+        $user->area_id = Area::where('area', $areaName)->inRandomOrder()->first()->id;
+        $this->professorsWithArea[$user->name] = [
+            'area_id' => $user->area_id,
+            'id' => $user->id,
+        ];
     }
 }


### PR DESCRIPTION
Adicionados métodos no TeacherScraping para associar professores a áreas e sub-áreas, extraindo dados do site do PGCOMP. Isso inclui lidar com nomes de professores incompatíveis. 

A atribuição de sub-áreas está sendo realizada de forma aleatória. 