### PR TITLE
Corrige bug SigaaScraping e remove coluna subarea da tabela "areas"

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -35,24 +35,12 @@ Responsável pelo serviço de recuperação dos dados (através de web scraping)
 ```bash
 
 # Iniciar projeto backend
-./vendor/bin/sail artisan migrate #(ou importar dump do banco de dados)
+./vendor/bin/sail artisan migrate:fresh #(Isso apagará todos os dados!)
 
 # Gerar chave de autenticação
 ./vendor/bin/sail artisan key:generate
 
-# SIGAA Web Scraping
-./vendor/bin/sail artisan scraping:area-subarea-scraping
-./vendor/bin/sail artisan scraping:sigaa-scraping --help
-./vendor/bin/sail artisan scraping:sigaa-scraping
-./vendor/bin/sail artisan scraping:qualis-conference-scraping
-./vendor/bin/sail artisan scraping:qualis-journal-scraping
+# Gerar principais dados
+./vendor/bin/sail artisan db:seed  # Inserir dados mockados
+./vendor/bin/sail artisan scraping:run # Executar todos os comandos de scraping
 
-# Carregando arquivos xml do lattes
-./vendor/bin/sail artisan load:lattes-files-load
-
-# Recriar base de dados
-./vendor/bin/sail artisan migrate:fresh #(Isso apagará todos os dados!)
-
-# Inserir dados falsos
-./vendor/bin/sail artisan db:seed #(Somente deve ser executado após de realizar o scraping)
-```

--- a/backend/app/Console/Commands/Scraping/AreaScrapingCommand.php
+++ b/backend/app/Console/Commands/Scraping/AreaScrapingCommand.php
@@ -8,11 +8,11 @@ use GuzzleHttp\Client;
 use Illuminate\Console\Command;
 use Illuminate\Support\Str;
 
-class AreaSubareaScrapingCommand extends Command
+class AreaScrapingCommand extends Command
 {
-    protected $signature = 'scraping:area-subarea-scraping';
+    protected $signature = 'scraping:area-scraping';
 
-    protected $description = 'Área Sub-area';
+    protected $description = 'Área Scraping';
 
 
     public function handle()

--- a/backend/app/Console/Commands/Scraping/AreaSubareaScrapingCommand.php
+++ b/backend/app/Console/Commands/Scraping/AreaSubareaScrapingCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Console\Commands;
+namespace App\Console\Commands\Scraping;
 
 use App\Models\Area;
 
@@ -8,7 +8,7 @@ use GuzzleHttp\Client;
 use Illuminate\Console\Command;
 use Illuminate\Support\Str;
 
-class AreaSubareaCommand extends Command
+class AreaSubareaScrapingCommand extends Command
 {
     protected $signature = 'scraping:area-subarea-scraping';
 

--- a/backend/app/Console/Commands/Scraping/AreaSubareaScrapingCommand.php
+++ b/backend/app/Console/Commands/Scraping/AreaSubareaScrapingCommand.php
@@ -27,57 +27,18 @@ class AreaSubareaScrapingCommand extends Command
         // Get areas after the first h1 tag with the text "Área de Concentração"
         $areas = $dom->find('.region.region-content .field-items ul > li')->getIterator();
 
+        $this->getOutput()->info('Coletando dados...');
+        $areaNames = [];
         foreach ($areas as $area) {
             // Get the area name. Find until the first dot ".'
             $areaName = $area->text();
             $areaName = Str::of($areaName)->before('.')->trim()->title()->value();
 
-            $areaLink = $area->find('a')->attr('href');
-
-            $this->generateSubArea($areaName, $areaLink);
-        }
-    }
-
-    private function generateSubArea(string $areaName, string $areaUrl): void
-    {
-
-        $this->info("\nAcessando a área: $areaName");
-        $subAreas = $this->getSubAreas($areaName, $areaUrl);
-        $rows = [];
-        foreach ($subAreas as $subAreaName) {
-            $area = Area::updateOrCreate(
-                ['area' => $areaName, 'subarea' => $subAreaName]
+            Area::updateOrCreate(
+                ['area' => $areaName]
             );
-            $rows[] = [$area->id, $area->area, $area->subarea, $area->wasRecentlyCreated ? 'Sim' : 'Não'];
+            $areaNames[] = $areaName;
         }
-        $this->table(
-            ['ID', 'Área', 'Subárea', 'Criada'],
-            $rows
-        );
-    }
-
-    private function getSubAreas(string $areaName, string $areaUrl): array
-    {
-        // "Engenharia de Software" is a special case. PGCOMP site does not have an explicit subarea for it.
-        if ($areaName == "Engenharia De Software") {
-            return  [
-                "Engenharia de Software"
-            ];
-        }
-
-        // Access the area link and get the subareas
-        $client = new Client();
-        $response = $client->request('GET', $areaUrl);
-        $html = $response->getBody()->getContents();
-        $dom = html5qp($html);
-        $subAreasIterator = $dom->find('.region.region-content .field-items ul > li')->getIterator();
-
-        foreach ($subAreasIterator as $subArea) {
-            // Get the subarea name. Find until the first dot ".'
-            $subAreaName = $subArea->text();
-            $subAreaName = Str::of($subAreaName)->before('.')->trim()->title()->value();
-            $subAreas[] = $subAreaName;
-        }
-        return $subAreas;
+        $this->getOutput()->info('Áreas coletadas: ' . implode(', ', $areaNames));
     }
 }

--- a/backend/app/Console/Commands/Scraping/ConferenceScrapingCommand.php
+++ b/backend/app/Console/Commands/Scraping/ConferenceScrapingCommand.php
@@ -63,7 +63,6 @@ class ConferenceScrapingCommand extends Command
 
         $this->getOutput()->info('Salvadno dados...');
         $this->withProgressBar($data, function ($item) {
-            print_r($item);
             try {
                 if (!isset($item['Qualis 2016'])) {
                     throw new ModelNotFoundException('ERROR');

--- a/backend/app/Console/Commands/Scraping/ConferenceScrapingCommand.php
+++ b/backend/app/Console/Commands/Scraping/ConferenceScrapingCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Console\Commands;
+namespace App\Console\Commands\Scraping;
 
 use App\Models\Conference;
 use App\Models\StratumQualis;

--- a/backend/app/Console/Commands/Scraping/JournalScrapingCommand.php
+++ b/backend/app/Console/Commands/Scraping/JournalScrapingCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Console\Commands;
+namespace App\Console\Commands\Scraping;
 
 use App\Models\Journal;
 use App\Models\StratumQualis;

--- a/backend/app/Console/Commands/Scraping/ScholarScrapingCommand.php
+++ b/backend/app/Console/Commands/Scraping/ScholarScrapingCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Console\Commands;
+namespace App\Console\Commands\Scraping;
 
 use App\Models\Conference;
 use App\Models\Journal;
@@ -182,7 +182,7 @@ class ScholarScrapingCommand extends Command
     private function saveTeacherArticles($author_url)
     {
         $proxy_server = $this->getProxy();
-        $client = PantherClient::createChromeClient(null, ['--no-sandbox', '--disable-dev-shm-usage', 
+        $client = PantherClient::createChromeClient(null, ['--no-sandbox', '--disable-dev-shm-usage',
         '--headless', '--remote-debugging-port=9222', "--proxy-server={$proxy_server}"]);
         $page_url = 'https://scholar.google.com' . $author_url;
 
@@ -203,7 +203,7 @@ class ScholarScrapingCommand extends Command
         $form_action = $author_url . '&view_op=list_works';
         $production_found = 0;
         $production_not_found = 0;
-        $crawler->filterXPath("//form[@action='{$form_action}']")->each(function (Crawler $row) 
+        $crawler->filterXPath("//form[@action='{$form_action}']")->each(function (Crawler $row)
             use (&$production_found, &$production_not_found) {
             $rows_on_node = $row->filter('table tr')->count();
             if ($rows_on_node > 0) {
@@ -257,19 +257,19 @@ class ScholarScrapingCommand extends Command
             $client = $this->getClient();
             $html = $client->get($page_url);
             $article_data = [];
-    
+
             $dom = html5qp($html->getBody()->getContents());
-    
+
             $dom->find('.gs_scl')->each(function ($idx, $dom_element) use (&$article_data) {
                 $div = qp($dom_element);
                 $field = $div->find('.gsc_oci_field')->text();
                 $value = $div->find('.gsc_oci_value')->text();
-    
+
                 if (!empty($field) && !empty($value)) {
                     $article_data[trim($field)] = trim($value);
                 }
             });
-    
+
             return $article_data;
         } catch(\Exception $e) {
             return 'get_error';

--- a/backend/app/Console/Commands/Scraping/Scraping.php
+++ b/backend/app/Console/Commands/Scraping/Scraping.php
@@ -12,7 +12,7 @@ class Scraping extends Command
      *
      * @var string
      */
-    protected $signature = 'scraping:run {class?*}';
+    protected $signature = 'scraping:run {class?* : Classes de scraping a serem executadas, separadas por espaço e sem o namespace}';
 
     /**
      * The console command description.
@@ -48,7 +48,11 @@ class Scraping extends Command
             }
 
             try {
+                $this->info("Executando {$class}...");
+                $this->newLine();
                 $this->call($class);
+                $this->info(str_repeat('-', 100));
+                $this->newLine();
             } catch (Exception $e) {
                 $this->error("Erro ao executar {$class}: " . $e->getMessage());
             }

--- a/backend/app/Console/Commands/Scraping/Scraping.php
+++ b/backend/app/Console/Commands/Scraping/Scraping.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Console\Commands\Scraping;
+
+use Exception;
+use Illuminate\Console\Command;
+
+class Scraping extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'scraping:run {class?*}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Run scraping commands';
+
+    protected string $baseNamespace = 'App\Console\Commands\Scraping\\';
+
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $classes = $this->argument('class');
+        if (empty($classes)) {
+            // load all classes from the scraping directory
+            $classes = [
+                'AreaSubareaScrapingCommand',
+                'SigaaScrapingCommand',
+                'ConferenceScrapingCommand',
+                'JournalScrapingCommand'
+            ];
+        }
+
+        foreach ($classes as $class) {
+            $class = $this->baseNamespace . $class;
+            if (!class_exists($class)) {
+                $this->error("Classe de scraping {$class} não existe.");
+                continue;
+            }
+
+            try {
+                $this->call($class);
+            } catch (Exception $e) {
+                $this->error("Erro ao executar {$class}: " . $e->getMessage());
+            }
+        }
+
+        return 0;
+    }
+}

--- a/backend/app/Console/Commands/Scraping/Scraping.php
+++ b/backend/app/Console/Commands/Scraping/Scraping.php
@@ -33,7 +33,7 @@ class Scraping extends Command
         if (empty($classes)) {
             // load all classes from the scraping directory
             $classes = [
-                'AreaSubareaScrapingCommand',
+                'AreaScrapingCommand',
                 'SigaaScrapingCommand',
                 'ConferenceScrapingCommand',
                 'JournalScrapingCommand'

--- a/backend/app/Console/Commands/Scraping/SigaaScrapingCommand.php
+++ b/backend/app/Console/Commands/Scraping/SigaaScrapingCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Console\Commands;
+namespace App\Console\Commands\Scraping;
 
 use App\Domain\Sigaa\DefenseScraping;
 use App\Domain\Sigaa\StudentScraping;
@@ -50,6 +50,11 @@ class SigaaScrapingCommand extends Command
             $teachers = $teacherScraping->scrapingByProgram((int)$programId);
             Storage::put("teachers-{$programId}.json", json_encode($teachers));
             $this->createOrUpdateTeachers($teachers);
+
+            $teachersWithArea = $teacherScraping->fillProfessorsWithArea();
+            $this->info('Professores com área preenchida com sucesso');
+
+
         } catch (Exception $e) {
             $this->error($e->getMessage());
         }
@@ -180,4 +185,5 @@ class SigaaScrapingCommand extends Command
             }
         }
     }
+
 }

--- a/backend/app/Console/Commands/Scraping/SigaaScrapingCommand.php
+++ b/backend/app/Console/Commands/Scraping/SigaaScrapingCommand.php
@@ -53,6 +53,11 @@ class SigaaScrapingCommand extends Command
 
             $teachersWithArea = $teacherScraping->fillProfessorsWithArea();
             $this->info('Professores com área preenchida com sucesso');
+            $this->table([
+                'Nome',
+                'ID Area',
+                'Observação'
+            ], $teachersWithArea);
 
 
         } catch (Exception $e) {

--- a/backend/app/Console/Commands/Scraping/SigaaScrapingCommand.php
+++ b/backend/app/Console/Commands/Scraping/SigaaScrapingCommand.php
@@ -187,6 +187,9 @@ class SigaaScrapingCommand extends Command
             }
             if ($teacher && $user->advisors()->where('id', $teacher->id)->doesntExist()) {
                 $user->advisors()->attach([$teacher->id => ['relation_type' => 'advisor']]);
+                $advisor = $user->advisors()->first();
+                $user->area_id = $advisor->area_id;
+                $user->save();
             }
         }
     }

--- a/backend/app/Console/Commands/Scraping/SigaaScrapingCommand.php
+++ b/backend/app/Console/Commands/Scraping/SigaaScrapingCommand.php
@@ -167,9 +167,11 @@ class SigaaScrapingCommand extends Command
 
             if ($user) {
                 $advisor = $user->advisors()->first();
+
                 if ($advisor) {
                     $user->area_id = $advisor->area_id;
                 }
+
                 $user->defended_at = $item['date'];
                 $user->save();
                 $this->info("{$user->name} defendeu.");
@@ -179,17 +181,20 @@ class SigaaScrapingCommand extends Command
                     ->first(['registration'])
                     ->registration;
 
+                $areaId = User::where('type', UserType::PROFESSOR->value)
+                    ->where('id', $teacher?->id)
+                    ->whereNotNull(['id','area_id'])
+                    ->first(['area_id'])?->area_id;
+
                 $user = User::createOrUpdateStudent([
                     'registration' => $registration -1,
                     'name' => $item['student'],
                     'course_id' => $item['course_id'],
+                    'area_id' => $areaId,
                 ]);
             }
             if ($teacher && $user->advisors()->where('id', $teacher->id)->doesntExist()) {
                 $user->advisors()->attach([$teacher->id => ['relation_type' => 'advisor']]);
-                $advisor = $user->advisors()->first();
-                $user->area_id = $advisor->area_id;
-                $user->save();
             }
         }
     }

--- a/backend/app/Models/Area.php
+++ b/backend/app/Models/Area.php
@@ -37,7 +37,6 @@ class Area extends BaseModel
 
     protected $fillable = [
         'area',
-        'subarea',
     ];
 
     /**
@@ -47,7 +46,6 @@ class Area extends BaseModel
     {
         return [
             'area' => 'required|string|max:255',
-            'subarea' => 'required|string|max:255',
         ];
     }
 

--- a/backend/database/migrations/2025_04_30_133140_drop_column_sub_area.php
+++ b/backend/database/migrations/2025_04_30_133140_drop_column_sub_area.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('areas', function (Blueprint $table) {
+            $table->dropColumn('subarea');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('areas', function (Blueprint $table) {
+            $table->string('subarea')->nullable();
+        });
+    }
+};

--- a/backend/database/seeders/DatabaseSeeder.php
+++ b/backend/database/seeders/DatabaseSeeder.php
@@ -16,11 +16,11 @@ class DatabaseSeeder extends Seeder
     {
         // \App\Models\User::factory(10)->create();
         $this->call(StratumQualisSeeder::class);
-        $this->call(AreaTableSeeder::class);
-        $this->call(SubareaTableSeeder::class);
-        $this->call(UserTableSeeder::class);
-        $this->call(JournalTableSeeder::class);
-        $this->call(ProductionTableSeeder::class);
-        $this->call(UserProductionTableSeeder::class);
+        // $this->call(AreaTableSeeder::class);
+        // $this->call(SubareaTableSeeder::class);
+        // $this->call(UserTableSeeder::class);
+        // $this->call(JournalTableSeeder::class);
+        // $this->call(ProductionTableSeeder::class);
+        // $this->call(UserProductionTableSeeder::class);
     }
 }


### PR DESCRIPTION
This pull request introduces several changes to the backend, focusing on simplifying the scraping commands, restructuring the codebase, and removing the concept of "subareas" from the application. Below is a summary of the most important changes grouped by theme:

### Simplification and Consolidation of Scraping Commands:
* Introduced a new `Scraping` command (`scraping:run`) that consolidates multiple scraping commands into a single entry point, allowing the execution of all or specific scraping commands dynamically. (`backend/app/Console/Commands/Scraping/Scraping.php`)
* Removed the `AreaSubareaCommand` and replaced it with a simplified `AreaScrapingCommand` that focuses only on scraping areas without subareas. (`backend/app/Console/Commands/AreaSubareaCommand.php`, `backend/app/Console/Commands/Scraping/AreaScrapingCommand.php`) [[1]](diffhunk://#diff-7fa2666d07fd540ddf80dc933fdde476a88247afc89083a9d443ef059b540536L1-L83) [[2]](diffhunk://#diff-8e4c485fb7c32b66222b3b138e759fe4bbd4a5070cb9fda88aa53624900174f1R1-R44)

### Codebase Restructuring:
* Moved all scraping-related commands into the `App\Console\Commands\Scraping` namespace for better organization. This includes commands for conferences, journals, SIGAA, and scholars. (`backend/app/Console/Commands/Scraping/ConferenceScrapingCommand.php`, `backend/app/Console/Commands/Scraping/JournalScrapingCommand.php`, `backend/app/Console/Commands/Scraping/ScholarScrapingCommand.php`, `backend/app/Console/Commands/Scraping/SigaaScrapingCommand.php`) [[1]](diffhunk://#diff-56adefc3a984d82945d7e4c6f8bfdb6703dc8f9aed2cb19f29db658c4903309aL3-R3) [[2]](diffhunk://#diff-25b986b86a32f6a0c779b3139ec535385ab5893152890dbba139aa295dcf9a02L3-R3) [[3]](diffhunk://#diff-7fb712b99127c816b4c237c4d61552e8982840cd6de6238e0bc3edfae920a612L3-R3) [[4]](diffhunk://#diff-117d2129c79ba9c451c3b990bf8c1a77c7bbb0a585dcf7a80113fdd99e1928aeL3-R3)

### Removal of Subareas:
* Dropped the `subarea` column from the `areas` table and updated related models and validation rules to reflect this removal. (`backend/database/migrations/2025_04_30_133140_drop_column_sub_area.php`, `backend/app/Models/Area.php`) [[1]](diffhunk://#diff-bc60296b2a8e3065eaabf1588431243cbf6eb41c5010412226b37520c72d6a7fR1-R29) [[2]](diffhunk://#diff-6dffaab7668ba93fa30ce409ac6e84edb63bfcd77c1223fc549051e1c807a39aL40) [[3]](diffhunk://#diff-6dffaab7668ba93fa30ce409ac6e84edb63bfcd77c1223fc549051e1c807a39aL50)
* Updated the `TeacherScraping` logic to handle professors only at the area level, removing references to subareas. (`backend/app/Domain/Sigaa/TeacherScraping.php`) [[1]](diffhunk://#diff-d51b7fb9be41a635af03af8b8870f9556bb99a2b9a5d4097be75f0c55c6878bdL100-R130) [[2]](diffhunk://#diff-d51b7fb9be41a635af03af8b8870f9556bb99a2b9a5d4097be75f0c55c6878bdL157-R169) [[3]](diffhunk://#diff-d51b7fb9be41a635af03af8b8870f9556bb99a2b9a5d4097be75f0c55c6878bdL182-R195)

### Updates to Data Seeding:
* Commented out several seeders in the `DatabaseSeeder` file, including those related to areas, subareas, and user production, as they are no longer relevant. (`backend/database/seeders/DatabaseSeeder.php`)

### Miscellaneous Fixes:
* Enhanced the `SigaaScrapingCommand` to include additional data handling for professors with areas, improving the accuracy of the scraping process. (`backend/app/Console/Commands/Scraping/SigaaScrapingCommand.php`) [[1]](diffhunk://#diff-117d2129c79ba9c451c3b990bf8c1a77c7bbb0a585dcf7a80113fdd99e1928aeR53-R62) [[2]](diffhunk://#diff-117d2129c79ba9c451c3b990bf8c1a77c7bbb0a585dcf7a80113fdd99e1928aeR184-R201)

These changes aim to streamline the scraping functionality, improve code organization, and eliminate unnecessary complexity in the data model.