### PR TITLE
feat/fix: Ajustes em filtros de projetos, reordenação de menu e legendas de gráficosFeat/add projects 291

### DIFF
--- a/backend/app/Http/Controllers/Admin/ProjectDashboardController.php
+++ b/backend/app/Http/Controllers/Admin/ProjectDashboardController.php
@@ -22,13 +22,15 @@ class ProjectDashboardController extends Controller
     {
         $validated = $request->validate([
             'professor_id' => 'nullable|integer|exists:users,id',
-            'year' => 'nullable|integer|min:1900',
+            'start_year' => 'nullable|integer|min:1900',
+            'end_year' => 'nullable|integer|min:1900',
             'status' => 'nullable|string',
         ]);
 
         $data = $this->service->getProjectsSummary(
             professorId: $validated['professor_id'] ?? null,
-            year: $validated['year'] ?? null,
+            startYear: $validated['start_year'] ?? null,
+            endYear: $validated['end_year'] ?? null,
             status: $validated['status'] ?? null,
         );
 
@@ -42,13 +44,15 @@ class ProjectDashboardController extends Controller
     {
         $validated = $request->validate([
             'professor_id' => 'nullable|integer|exists:users,id',
-            'year' => 'nullable|integer|min:1900',
+            'start_year' => 'nullable|integer|min:1900',
+            'end_year' => 'nullable|integer|min:1900',
             'status' => 'nullable|string',
         ]);
 
         $data = $this->service->getProjectsTable(
             professorId: $validated['professor_id'] ?? null,
-            year: $validated['year'] ?? null,
+            startYear: $validated['start_year'] ?? null,
+            endYear: $validated['end_year'] ?? null,
             status: $validated['status'] ?? null,
         );
 

--- a/backend/app/Http/Controllers/User/ProjectController.php
+++ b/backend/app/Http/Controllers/User/ProjectController.php
@@ -41,13 +41,7 @@ class ProjectController extends Controller
      */
     public function index(Request $request)
     {
-        //$projects = $this->projectService->getProjectsForUser($request->user()->id);
-        //return response()->json([ 'data' => $projects ]);
-        try {
-        $projects = $request->user()->projects; 
+        $projects = $this->projectService->getProjectsForUser($request->user()->id);
         return response()->json([ 'data' => $projects ]);
-    } catch (\Exception $e) {
-        return response()->json(['error' => $e->getMessage()], 500);
-    }
     }
 }

--- a/backend/app/Services/ProjectDashboardService.php
+++ b/backend/app/Services/ProjectDashboardService.php
@@ -12,7 +12,7 @@ class ProjectDashboardService
     /**
      * Get project consolidation summary with filters.
      */
-    public function getProjectsSummary(?int $professorId = null, ?int $year = null, ?string $status = null)
+    public function getProjectsSummary(?int $professorId = null, ?int $startYear = null, ?int $endYear = null, ?string $status = null)
     {
         $query = Project::query()
             ->when($professorId, function ($q) use ($professorId) {
@@ -20,12 +20,14 @@ class ProjectDashboardService
                     $q->where('users.id', $professorId);
                 });
             })
-            ->when($year, function ($q) use ($year) {
-                $q->where('start_year', '<=', $year)
-                    ->where(function ($q) use ($year) {
-                        $q->where('end_year', '>=', $year)
-                            ->orWhereNull('end_year');
-                    });
+             $query = Project::query()
+            ->when($startYear, function ($q) use ($startYear) {
+            $q->where('start_year', '>=', $startYear);
+            })
+           ->when($endYear, function ($q) use ($endYear) {
+            $q->where(function ($q) use ($endYear) {
+                $q->where('end_year', '<=', $endYear)->orWhereNull('end_year');
+            });
             })
             ->when($status, function ($q) use ($status) {
                 $q->where('status', $status);
@@ -47,7 +49,7 @@ class ProjectDashboardService
     /**
      * Get projects list for table with filters.
      */
-    public function getProjectsTable(?int $professorId = null, ?int $year = null, ?string $status = null)
+    public function getProjectsSummary(?int $professorId = null, ?int $startYear = null, ?int $endYear = null, ?string $status = null)
     {
         return Project::with('participants:id,name')
             ->when($professorId, function ($q) use ($professorId) {
@@ -55,12 +57,14 @@ class ProjectDashboardService
                     $q->where('users.id', $professorId);
                 });
             })
-            ->when($year, function ($q) use ($year) {
-                $q->where('start_year', '<=', $year)
-                    ->where(function ($q) use ($year) {
-                        $q->where('end_year', '>=', $year)
-                            ->orWhereNull('end_year');
-                    });
+            $query = Project::query()
+           ->when($startYear, function ($q) use ($startYear) {
+            $q->where('start_year', '>=', $startYear);
+            })
+           ->when($endYear, function ($q) use ($endYear) {
+            $q->where(function ($q) use ($endYear) {
+                $q->where('end_year', '<=', $endYear)->orWhereNull('end_year');
+            });
             })
             ->when($status, function ($q) use ($status) {
                 $q->where('status', $status);

--- a/backend/app/Services/ProjectDashboardService.php
+++ b/backend/app/Services/ProjectDashboardService.php
@@ -20,22 +20,9 @@ class ProjectDashboardService
                     $q->where('users.id', $professorId);
                 });
             })
-         ->when($startYear || $endYear, function ($q) use ($startYear, $endYear) {
-         $q->where(function ($q) use ($startYear, $endYear) {
-        
-             if ($endYear) {
-               $q->where('start_year', '<=', $endYear);
-              }
-        
-             if ($startYear) {
-                $q->where(function ($q) use ($startYear) {
-                $q->where('end_year', '>=', $startYear)
-                  ->orWhereNull('end_year');
-                 });
-               }
-             });
-           })
-            ->when($status, function ($q) use ($status) {
+         ->when($startYear, fn($q) => $q->where('start_year', '>=', $startYear))
+         ->when($endYear, fn($q) => $q->where('start_year', '<=', $endYear))
+         ->when($status, function ($q) use ($status) {
                 $q->where('status', $status);
             });
 

--- a/backend/app/Services/ProjectDashboardService.php
+++ b/backend/app/Services/ProjectDashboardService.php
@@ -20,15 +20,21 @@ class ProjectDashboardService
                     $q->where('users.id', $professorId);
                 });
             })
-             $query = Project::query()
-            ->when($startYear, function ($q) use ($startYear) {
-            $q->where('start_year', '>=', $startYear);
-            })
-           ->when($endYear, function ($q) use ($endYear) {
-            $q->where(function ($q) use ($endYear) {
-                $q->where('end_year', '<=', $endYear)->orWhereNull('end_year');
-            });
-            })
+         ->when($startYear || $endYear, function ($q) use ($startYear, $endYear) {
+         $q->where(function ($q) use ($startYear, $endYear) {
+        
+             if ($endYear) {
+               $q->where('start_year', '<=', $endYear);
+              }
+        
+             if ($startYear) {
+                $q->where(function ($q) use ($startYear) {
+                $q->where('end_year', '>=', $startYear)
+                  ->orWhereNull('end_year');
+                 });
+               }
+             });
+           })
             ->when($status, function ($q) use ($status) {
                 $q->where('status', $status);
             });
@@ -49,7 +55,7 @@ class ProjectDashboardService
     /**
      * Get projects list for table with filters.
      */
-    public function getProjectsSummary(?int $professorId = null, ?int $startYear = null, ?int $endYear = null, ?string $status = null)
+    public function getProjectsTable(?int $professorId = null, ?int $startYear = null, ?int $endYear = null, ?string $status = null)
     {
         return Project::with('participants:id,name')
             ->when($professorId, function ($q) use ($professorId) {
@@ -57,15 +63,21 @@ class ProjectDashboardService
                     $q->where('users.id', $professorId);
                 });
             })
-            $query = Project::query()
-           ->when($startYear, function ($q) use ($startYear) {
-            $q->where('start_year', '>=', $startYear);
-            })
-           ->when($endYear, function ($q) use ($endYear) {
-            $q->where(function ($q) use ($endYear) {
-                $q->where('end_year', '<=', $endYear)->orWhereNull('end_year');
-            });
-            })
+            ->when($startYear || $endYear, function ($q) use ($startYear, $endYear) {
+         $q->where(function ($q) use ($startYear, $endYear) {
+        
+             if ($endYear) {
+               $q->where('start_year', '<=', $endYear);
+              }
+        
+             if ($startYear) {
+                $q->where(function ($q) use ($startYear) {
+                $q->where('end_year', '>=', $startYear)
+                  ->orWhereNull('end_year');
+                 });
+               }
+             });
+           })
             ->when($status, function ($q) use ($status) {
                 $q->where('status', $status);
             })

--- a/frontend/src/features/dashboard/components/charts/ProductionPerQualis.tsx
+++ b/frontend/src/features/dashboard/components/charts/ProductionPerQualis.tsx
@@ -118,7 +118,7 @@ export default function ProductionPerQualisChart() {
                 }))}
               />
               <Tooltip />
-              {allQualis.reverse().map((qualis) => (
+              {[...allQualis].reverse().map((qualis) => (
                 <Bar
                   key={qualis}
                   dataKey={qualis}

--- a/frontend/src/features/projects/components/ProjectHeader.tsx
+++ b/frontend/src/features/projects/components/ProjectHeader.tsx
@@ -1,4 +1,17 @@
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { Professor } from '@/types/user';
+
+const YEARS = Array.from(
+  { length: new Date().getFullYear() - 2000 + 1 },
+  (_, i) => 2000 + i,
+).reverse();
 
 interface ProjectHeaderProps {
   isAdmin?: boolean;
@@ -7,6 +20,10 @@ interface ProjectHeaderProps {
   selectedProfessorId: string;
   onProfessorChange: (value: string) => void;
   professorsList: Professor[];
+  startYear: number | null;
+  endYear: number | null;
+  onStartYearChange: (value: number | null) => void;
+  onEndYearChange: (value: number | null) => void;
 }
 
 export function ProjectHeader({
@@ -16,30 +33,79 @@ export function ProjectHeader({
   selectedProfessorId,
   onProfessorChange,
   professorsList,
+  startYear,
+  endYear,
+  onStartYearChange,
+  onEndYearChange,
 }: ProjectHeaderProps) {
   return (
     <div className="flex flex-col gap-2">
       <h1 className="text-3xl font-bold">Projetos</h1>
       <p className="text-muted-foreground">Visualize, crie e edite projetos.</p>
 
-      {isAdmin && (
-        <div className="flex items-center gap-2 mt-2">
-          <select
-            aria-label="Selecionar professor"
-            className="border rounded-md px-3 py-2 text-sm"
-            value={selectedProfessorId}
-            onChange={(e) => onProfessorChange(e.target.value)}
-            disabled={isLoading || isPending}
+      <div className="flex flex-wrap items-end gap-4 mt-2 bg-muted/40 p-4 rounded-lg border">
+        {isAdmin && (
+          <div className="flex flex-col gap-2">
+            <Label className="text-xs uppercase tracking-wider text-muted-foreground font-semibold">
+              Docente
+            </Label>
+            <select
+              aria-label="Selecionar professor"
+              className="border rounded-md px-3 py-2 text-sm"
+              value={selectedProfessorId}
+              onChange={(e) => onProfessorChange(e.target.value)}
+              disabled={isLoading || isPending}
+            >
+              <option value="own">Meus projetos</option>
+              {professorsList.map((professor) => (
+                <option key={professor.id} value={String(professor.id)}>
+                  {professor.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+
+        <div className="flex flex-col gap-2">
+          <Label className="text-xs uppercase tracking-wider text-muted-foreground font-semibold">
+            Início
+          </Label>
+          <Select
+            value={startYear?.toString() ?? 'all'}
+            onValueChange={(v) => onStartYearChange(v === 'all' ? null : parseInt(v))}
           >
-            <option value="own">Meus projetos</option>
-            {professorsList.map((professor) => (
-              <option key={professor.id} value={String(professor.id)}>
-                {professor.name}
-              </option>
-            ))}
-          </select>
+            <SelectTrigger className="w-32 bg-background">
+              <SelectValue placeholder="Todos" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">Todos</SelectItem>
+              {YEARS.map((year) => (
+                <SelectItem key={year} value={year.toString()}>{year}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
         </div>
-      )}
+
+        <div className="flex flex-col gap-2">
+          <Label className="text-xs uppercase tracking-wider text-muted-foreground font-semibold">
+            Fim
+          </Label>
+          <Select
+            value={endYear?.toString() ?? 'all'}
+            onValueChange={(v) => onEndYearChange(v === 'all' ? null : parseInt(v))}
+          >
+            <SelectTrigger className="w-32 bg-background">
+              <SelectValue placeholder="Todos" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">Todos</SelectItem>
+              {YEARS.map((year) => (
+                <SelectItem key={year} value={year.toString()}>{year}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/src/features/projects/components/columns.tsx
+++ b/frontend/src/features/projects/components/columns.tsx
@@ -8,13 +8,13 @@ import {
   AlertDialogPortal,
   AlertDialogTitle,
   AlertDialogTrigger,
-} from "@/components/ui/alert-dialog";
-import { Button } from "@/components/ui/button";
-import { DataTableColumnHeader } from "@/components/ui/data-table-column-header";
-import { Project } from "@/types/academic";
-import { ColumnDef, createColumnHelper } from "@tanstack/react-table";
-import { SquarePenIcon, Trash } from "lucide-react";
-import { Link } from "react-router";
+} from '@/components/ui/alert-dialog';
+import { Button } from '@/components/ui/button';
+import { DataTableColumnHeader } from '@/components/ui/data-table-column-header';
+import { Project } from '@/types/academic';
+import { ColumnDef, createColumnHelper } from '@tanstack/react-table';
+import { SquarePenIcon, Trash } from 'lucide-react';
+import { Link } from 'react-router';
 
 const columnHelper = createColumnHelper<Project>();
 
@@ -33,17 +33,17 @@ export const getProjectColumns = ({
   selectedProject,
   setProjectToDelete,
 }: GetProjectColumnsProps): ColumnDef<Project, any>[] => [
-  columnHelper.accessor("name", {
-    id: "name",
+  columnHelper.accessor('name', {
+    id: 'name',
     header: ({ column }) => (
       <DataTableColumnHeader column={column} title="Nome" />
     ),
     cell: (info) => (
       <div className="text-left align-top">
         <Link
-          to={info.row.original.home_page || "#"}
-          target={info.row.original.home_page ? "_blank" : ""}
-          rel={info.row.original.home_page ? "noopener noreferrer" : undefined}
+          to={info.row.original.home_page || '#'}
+          target={info.row.original.home_page ? '_blank' : ''}
+          rel={info.row.original.home_page ? 'noopener noreferrer' : undefined}
         >
           <div className="text-sm leading-snug whitespace-normal wrap-break-word text-justify">
             {info.getValue()}
@@ -51,69 +51,76 @@ export const getProjectColumns = ({
         </Link>
       </div>
     ),
-    meta: { className: "w-[30%]" },
+    meta: { className: 'w-[30%]' },
   }),
-  columnHelper.accessor("start_year", {
-    id: "start_year",
+  columnHelper.accessor('start_year', {
+    id: 'start_year',
     header: ({ column }) => (
       <DataTableColumnHeader column={column} title="Início" />
     ),
     cell: (info) => (
       <div className="text-center text-sm">{info.getValue()}</div>
     ),
-    meta: { className: "w-[8%]" },
+    meta: { className: 'w-[8%]' },
   }),
-  columnHelper.accessor("end_year", {
-    id: "end_year",
+  columnHelper.accessor('end_year', {
+    id: 'end_year',
     header: ({ column }) => (
       <DataTableColumnHeader column={column} title="Fim" />
     ),
     cell: (info) => (
-      <div className="text-center text-sm">{info.getValue() || "Em andamento"}</div>
+      <div className="text-center text-sm">{info.getValue() || 'Em andamento'}</div>
     ),
-    meta: { className: "w-[10%]" },
+    meta: { className: 'w-[10%]' },
   }),
-  columnHelper.accessor("status", {
-    id: "status",
+  columnHelper.accessor('status', {
+    id: 'status',
     header: ({ column }) => (
       <DataTableColumnHeader column={column} title="Status" />
     ),
-    cell: (info) => (
-      <div className="text-center text-sm">{info.getValue() || "--"}</div>
-    ),
-    meta: { className: "w-[10%]" },
+    cell: (info) => {
+      const val = info.getValue();
+      if (!val) return <div className="text-center text-sm">--</div>;
+      const s = val.toUpperCase();
+      if (s.includes('ANDAMENTO')) return <div className="text-center"><span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">Em Andamento</span></div>;
+      if (s.includes('CONCLU')) return <div className="text-center"><span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">Concluído</span></div>;
+      return <div className="text-center text-sm">{val.charAt(0).toUpperCase() + val.slice(1).toLowerCase()}</div>;
+    },
+    meta: { className: 'w-[10%]' },
   }),
-  columnHelper.accessor("nature", {
-    id: "nature",
+  columnHelper.accessor('nature', {
+    id: 'nature',
     header: ({ column }) => (
       <DataTableColumnHeader column={column} title="Natureza" />
     ),
-    cell: (info) => (
-      <div className="text-center text-sm">{info.getValue() || "--"}</div>
-    ),
-    meta: { className: "w-[10%]" },
+    cell: (info) => {
+      const val = info.getValue();
+      if (!val) return <div className="text-center text-sm">--</div>;
+      return <div className="text-center text-sm">{val.charAt(0).toUpperCase() + val.slice(1).toLowerCase()}</div>;
+    },
+    meta: { className: 'w-[10%]' },
   }),
-  columnHelper.accessor("funding_source", {
-    id: "funding_source",
+  columnHelper.accessor('funding_source', {
+    id: 'funding_source',
     header: ({ column }) => (
       <DataTableColumnHeader column={column} title="Fomento" />
     ),
     cell: (info) => (
-      <div className="text-center text-sm">{info.getValue() || "--"}</div>
+      <div className="text-center text-sm">{info.getValue() || '--'}</div>
     ),
-    meta: { className: "w-[10%]" },
+    meta: { className: 'w-[10%]' },
   }),
   columnHelper.accessor((row) => row.pivot?.role, {
-    id: "role",
-    header: () => "Função",
+    id: 'role',
+    header: () => 'Função',
     cell: (info) => (
-      <div className="text-center text-sm">{info.getValue() || "--"}</div>
+      <div className="text-center text-sm">{info.getValue() || '--'}</div>
     ),
-    meta: { className: "w-[8%]" },
+    meta: { className: 'w-[8%]' },
   }),
   columnHelper.display({
-    id: "actions",
-    header: () => "Ações",
+    id: 'actions',
+    header: () => 'Ações',
     cell: ({ row }) => {
       const project = row.original;
       return (
@@ -169,6 +176,6 @@ export const getProjectColumns = ({
         </div>
       );
     },
-    meta: { className: "w-[11%]" },
+    meta: { className: 'w-[11%]' },
   }),
 ];

--- a/frontend/src/features/projects/hooks/useProjectData.ts
+++ b/frontend/src/features/projects/hooks/useProjectData.ts
@@ -27,14 +27,24 @@ export function useProjectData() {
     },
     enabled: !!auth?.isAuthenticated && (auth?.isAdmin ? selectedProfessorId !== 'own' : true),
   });
+  const [startYear, setStartYear] = useState<number | null>(null);
+  const [endYear, setEndYear] = useState<number | null>(null);
 
   const projects = useMemo(() => {
     if (!rawData) return [];
     return Object.entries(rawData)
       .filter(([key]) => !isNaN(Number(key)))
       .map(([, value]) => value as unknown as Project)
+      .filter((p) => {
+        if (startYear && endYear) {
+          return p.start_year <= endYear && (p.end_year == null || p.end_year >= startYear);
+        }
+        if (startYear) return p.end_year == null || p.end_year >= startYear;
+        if (endYear) return p.start_year <= endYear;
+        return true;
+      })
       .sort((a, b) => b.start_year - a.start_year);
-  }, [rawData]);
+  },  [rawData, startYear, endYear]);
 
   const handleProfessorChange = (value: string) => {
     startTransition(() => {
@@ -50,5 +60,9 @@ export function useProjectData() {
     professorsList,
     selectedProfessorId,
     handleProfessorChange,
+    startYear, 
+    setStartYear, 
+    endYear, 
+    setEndYear,
   };
 }

--- a/frontend/src/features/projects/hooks/useProjectData.ts
+++ b/frontend/src/features/projects/hooks/useProjectData.ts
@@ -1,24 +1,25 @@
+import { configurationService } from '@/services/modules/configuration.service';
 import useAuth from '@/hooks/auth';
 import { projectService } from '@/services/modules/project.service';
 import { professorService } from '@/services/modules/professor.service';
 import { Project } from '@/types/academic';
 import { useQuery } from '@tanstack/react-query';
-import { useMemo, useState, useTransition } from 'react';
+import { useEffect, useMemo, useState, useTransition } from 'react';
 
 export function useProjectData() {
   const auth = useAuth();
-  const [selectedProfessorId, setSelectedProfessorId] = useState<string>('own');
-  const [isPending, startTransition] = useTransition();
+  const [ selectedProfessorId, setSelectedProfessorId ] = useState<string>('own');
+  const [ isPending, startTransition ] = useTransition();
 
   const { data: professorsData } = useQuery({
-    queryKey: ['professors', 'full'],
+    queryKey: [ 'professors', 'full' ],
     queryFn: () => professorService.fetchProfessors({ paginate: 'false' }),
     enabled: !!auth && auth.isAdmin === true,
   });
-  const professorsList = useMemo(() => professorsData?.data || [], [professorsData]);
+  const professorsList = useMemo(() => professorsData?.data || [], [ professorsData ]);
 
   const { data: rawData, isLoading } = useQuery<Project[], Error>({
-    queryKey: ['projects', selectedProfessorId, auth?.isAdmin],
+    queryKey: [ 'projects', selectedProfessorId, auth?.isAdmin ],
     queryFn: () => {
       if (auth?.isAdmin && selectedProfessorId !== 'own') {
         return projectService.getUserProjects(Number(selectedProfessorId));
@@ -27,21 +28,30 @@ export function useProjectData() {
     },
     enabled: !!auth?.isAuthenticated && (auth?.isAdmin ? selectedProfessorId !== 'own' : true),
   });
-  const [startYear, setStartYear] = useState<number | null>(null);
-  const [endYear, setEndYear] = useState<number | null>(null);
+  const [ startYear, setStartYear ] = useState<number | null>(null);
+  const [ endYear, setEndYear ] = useState<number | null>(null);
+  const { data: rulesData } = useQuery({
+    queryKey: [ 'rulesYears' ],
+    queryFn: () => configurationService.getRulesEndAndStartYears(),
+  });
+
+  useEffect(() => {
+    if (rulesData?.startYear) setStartYear(rulesData.startYear);
+    if (rulesData?.endYear) setEndYear(rulesData.endYear);
+  }, [ rulesData ]);
 
   const projects = useMemo(() => {
     if (!rawData) return [];
     return Object.entries(rawData)
-      .filter(([key]) => !isNaN(Number(key)))
-      .map(([, value]) => value as unknown as Project)
+      .filter(([ key ]) => !isNaN(Number(key)))
+      .map(([ , value ]) => value as unknown as Project)
       .filter((p) => {
         if (startYear && p.start_year < startYear) return false;
         if (endYear && p.start_year > endYear) return false;
         return true;
       })
       .sort((a, b) => b.start_year - a.start_year);
-  }, [rawData, startYear, endYear]);
+  }, [ rawData, startYear, endYear ]);
 
   const handleProfessorChange = (value: string) => {
     startTransition(() => {

--- a/frontend/src/features/projects/hooks/useProjectData.ts
+++ b/frontend/src/features/projects/hooks/useProjectData.ts
@@ -36,15 +36,12 @@ export function useProjectData() {
       .filter(([key]) => !isNaN(Number(key)))
       .map(([, value]) => value as unknown as Project)
       .filter((p) => {
-        if (startYear && endYear) {
-          return p.start_year <= endYear && (p.end_year == null || p.end_year >= startYear);
-        }
-        if (startYear) return p.end_year == null || p.end_year >= startYear;
-        if (endYear) return p.start_year <= endYear;
+        if (startYear && p.start_year < startYear) return false;
+        if (endYear && p.start_year > endYear) return false;
         return true;
       })
       .sort((a, b) => b.start_year - a.start_year);
-  },  [rawData, startYear, endYear]);
+  }, [rawData, startYear, endYear]);
 
   const handleProfessorChange = (value: string) => {
     startTransition(() => {
@@ -60,9 +57,9 @@ export function useProjectData() {
     professorsList,
     selectedProfessorId,
     handleProfessorChange,
-    startYear, 
-    setStartYear, 
-    endYear, 
+    startYear,
+    setStartYear,
+    endYear,
     setEndYear,
   };
 }

--- a/frontend/src/layouts/admin/components/admin-sidebar.tsx
+++ b/frontend/src/layouts/admin/components/admin-sidebar.tsx
@@ -1,7 +1,7 @@
-import { BarChart2, BookOpen, File, Settings2, Trophy, Users } from "lucide-react";
-import { Link, useLocation } from "react-router";
+import { BarChart2, BookOpen, File, Settings2, Trophy, Users } from 'lucide-react';
+import { Link, useLocation } from 'react-router';
 
-import AppLogo from "@/components/AppLogo";
+import AppLogo from '@/components/AppLogo';
 import {
   Sidebar,
   SidebarContent,
@@ -9,8 +9,8 @@ import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
-} from "@/components/ui/sidebar";
-import useAuth from "@/hooks/auth";
+} from '@/components/ui/sidebar';
+import useAuth from '@/hooks/auth';
 
 export function AdminSidebar() {
   const auth = useAuth();
@@ -27,17 +27,17 @@ export function AdminSidebar() {
       </SidebarHeader>
       <SidebarContent>
         <SidebarMenu>
+
+          {/* Início */}
           <SidebarMenuItem>
-            <SidebarMenuButton asChild isActive={pathname === "/"}>
-              <Link to="/" data-cy="link-areas">
+            <SidebarMenuButton asChild isActive={pathname === '/'}>
+              <Link to="/">
                 <Users className="h-4 w-4" />
                 <span>Início</span>
               </Link>
             </SidebarMenuButton>
           </SidebarMenuItem>
-          {auth?.isAdmin && (
-            <>
-              {/* <SidebarMenuItem>
+          {/* <SidebarMenuItem>
                 <SidebarMenuButton
                   asChild
                   isActive={pathname === "/admin/dashboard"}
@@ -48,7 +48,7 @@ export function AdminSidebar() {
                   </Link>
                 </SidebarMenuButton>
               </SidebarMenuItem> */}
-              {/* <SidebarMenuItem>
+          {/* <SidebarMenuItem>
                 <SidebarMenuButton
                   asChild
                   isActive={pathname === "/admin/areas"}
@@ -59,47 +59,33 @@ export function AdminSidebar() {
                   </Link>
                 </SidebarMenuButton>
               </SidebarMenuItem> */}
+          {/* Projetos Individuais */}
+          <SidebarMenuItem>
+            <SidebarMenuButton asChild isActive={pathname === '/portal/projects'}>
+              <Link to="/portal/projects">
+                <File className="h-4 w-4" />
+                <span>Projetos Individuais</span>
+              </Link>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+          {auth?.isAdmin && (
+            <>
+              {/* Projetos PGCOMP */}
               <SidebarMenuItem>
-                <SidebarMenuButton
-                  asChild
-                  isActive={pathname === "/admin/qualis"}
-                >
+                <SidebarMenuButton asChild isActive={pathname === '/admin/projects-dashboard'}>
+                  <Link to="/admin/projects-dashboard">
+                    <BarChart2 className="h-4 w-4" />
+                    <span>Projetos PGCOMP</span>
+                  </Link>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+              {/* Qualis */}
+              <SidebarMenuItem>
+                <SidebarMenuButton asChild isActive={pathname === '/admin/qualis'}>
                   <Link to="/admin/qualis">
                     <BookOpen className="h-4 w-4" />
                     <span>Qualis</span>
-                  </Link>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-              <SidebarMenuItem>
-                <SidebarMenuButton
-                  asChild
-                  isActive={pathname === "/admin/publishers"}
-                >
-                  <Link
-                    to="/admin/publishers"
-                    className="flex items-center justify-between w-full"
-                  >
-                    <div className="flex items-center gap-2">
-                      <BookOpen className="h-4 w-4" />
-                      <span>Veículos</span>
-                    </div>
-                  </Link>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-              <SidebarMenuItem>
-                <SidebarMenuButton
-                  asChild
-                  isActive={pathname === "/admin/professors"}
-                >
-                  <Link
-                    to="/admin/professors"
-                    className="flex items-center justify-between w-full"
-                  >
-                    <div className="flex items-center gap-2">
-                      <Users className="h-4 w-4" />
-                      <span>Docentes</span>
-                    </div>
-                  </Link>
+                  </Link>=
                 </SidebarMenuButton>
               </SidebarMenuItem>
               {/* <SidebarMenuItem>
@@ -113,11 +99,27 @@ export function AdminSidebar() {
                   </Link>
                 </SidebarMenuButton>
               </SidebarMenuItem> */}
+              {/* Veículos */}
               <SidebarMenuItem>
-                <SidebarMenuButton
-                  asChild
-                  isActive={pathname === "/admin/rules"}
-                >
+                <SidebarMenuButton asChild isActive={pathname === '/admin/publishers'}>
+                  <Link to="/admin/publishers">
+                    <BookOpen className="h-4 w-4" />
+                    <span>Veículos</span>
+                  </Link>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+              {/* Docentes */}
+              <SidebarMenuItem>
+                <SidebarMenuButton asChild isActive={pathname === '/admin/professors'}>
+                  <Link to="/admin/professors">
+                    <Users className="h-4 w-4" />
+                    <span>Docentes</span>
+                  </Link>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+              {/* Regras */}
+              <SidebarMenuItem>
+                <SidebarMenuButton asChild isActive={pathname === '/admin/rules'}>
                   <Link to="/admin/rules">
                     <Settings2 className="h-4 w-4" />
                     <span>Regras</span>
@@ -129,10 +131,7 @@ export function AdminSidebar() {
 
           {auth?.isManager && (
             <SidebarMenuItem>
-              <SidebarMenuButton
-                asChild
-                isActive={pathname === "/admin/lattes-uploads"}
-              >
+              <SidebarMenuButton asChild isActive={pathname === '/admin/lattes-uploads'}>
                 <Link to="/admin/lattes-uploads">
                   <File className="h-4 w-4" />
                   <span>XML Lattes</span>
@@ -141,11 +140,9 @@ export function AdminSidebar() {
             </SidebarMenuItem>
           )}
 
+          {/* Produções */}
           <SidebarMenuItem>
-            <SidebarMenuButton
-              asChild
-              isActive={pathname === "/portal/productions"}
-            >
+            <SidebarMenuButton asChild isActive={pathname === '/portal/productions'}>
               <Link to="/portal/productions">
                 <File className="h-4 w-4" />
                 <span>Produções</span>
@@ -154,22 +151,7 @@ export function AdminSidebar() {
           </SidebarMenuItem>
 
           <SidebarMenuItem>
-            <SidebarMenuButton
-              asChild
-              isActive={pathname === "/portal/projects"}
-            >
-              <Link to="/portal/projects">
-                <File className="h-4 w-4" />
-                <span>Projetos Individuais</span>
-              </Link>
-            </SidebarMenuButton>
-          </SidebarMenuItem>
-
-          <SidebarMenuItem>
-            <SidebarMenuButton
-              asChild
-              isActive={pathname === "/admin/credenciamento"}
-            >
+            <SidebarMenuButton asChild isActive={pathname === '/admin/credenciamento'}>
               <Link to="/admin/credenciamento">
                 <Trophy className="h-4 w-4" />
                 <span>Credenciamento</span>
@@ -177,17 +159,6 @@ export function AdminSidebar() {
             </SidebarMenuButton>
           </SidebarMenuItem>
 
-          <SidebarMenuItem>
-            <SidebarMenuButton
-              asChild
-              isActive={pathname === "/admin/projects-dashboard"}
-            >
-              <Link to="/admin/projects-dashboard">
-                <BarChart2 className="h-4 w-4" />
-                <span>Projetos PGCOMP</span>
-              </Link>
-            </SidebarMenuButton>
-          </SidebarMenuItem>
         </SidebarMenu>
       </SidebarContent>
     </Sidebar>

--- a/frontend/src/pages/user/projects/index.tsx
+++ b/frontend/src/pages/user/projects/index.tsx
@@ -23,6 +23,10 @@ export default function ProjectsPage() {
     professorsList,
     selectedProfessorId,
     handleProfessorChange,
+    startYear,
+    setStartYear,
+    endYear,
+    setEndYear,
   } = useProjectData();
 
   const crud = useProjectCrud(selectedProfessorId);
@@ -36,8 +40,12 @@ export default function ProjectsPage() {
         selectedProfessorId={selectedProfessorId}
         onProfessorChange={handleProfessorChange}
         professorsList={professorsList}
-      />
+        startYear={startYear}
+        endYear={endYear}
+        onStartYearChange={setStartYear}
+        onEndYearChange={setEndYear}
 
+      />
       <div className="bg-background border rounded-xl shadow-sm overflow-hidden p-6">
         <div className="flex items-center gap-2 mb-6">
           {chosenForm !== 'none' && (
@@ -66,7 +74,7 @@ export default function ProjectsPage() {
                   Importar XML
                 </Button>
               )}
-              <ClearProjectsDialog onConfirm={crud.fullDelete} /> 
+              <ClearProjectsDialog onConfirm={crud.fullDelete} />
               <Button onClick={() => setChosenForm('manual')}>
                 + Adicionar
               </Button>


### PR DESCRIPTION
Menu Lateral: Reordenação dos itens da navegação, movendo as opções de Projetos Individuais e Projetos PGCOMP mais para cima na lista.

Filtros de Data em Projetos: Implementação e correção dos filtros de ano (Início e Fim). Resolvido o bug onde projetos fora do escopo selecionado (ex: projetos de 2019 em filtros de 2023-2026) eram retornados indevidamente. Aplicado para a visão geral e individual.

Filtro de Sessão ("Meus Projetos"): Correção na query/filtro da dropdown "Meus projetos" para que retorne estritamente os projetos vinculados ao usuário autenticado na sessão atual.

Legendas de Gráfico (Qualis): Inversão da ordem da legenda nos gráficos, garantindo que as classificações mais altas (como A1) sejam exibidas no topo, melhorando a leitura dos dados.